### PR TITLE
efficient parsing of big files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/*
 *.pyc
 *.*.swp
 .coverage
+/.project
+/.pydevproject

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/*
 .coverage
 /.project
 /.pydevproject
+.settings/*

--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,1 +1,0 @@
-/org.eclipse.core.resources.prefs

--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,0 +1,1 @@
+/org.eclipse.core.resources.prefs

--- a/eegtools/io/edfplus.py
+++ b/eegtools/io/edfplus.py
@@ -12,7 +12,6 @@ Copyright (c) 2012 Boris Reuderink.
 
 import re, datetime, operator, logging
 import numpy as np
-import io
 from collections import namedtuple
 
 EVENT_CHANNEL = 'EDF Annotations'

--- a/eegtools/io/edfplus.py
+++ b/eegtools/io/edfplus.py
@@ -12,6 +12,7 @@ Copyright (c) 2012 Boris Reuderink.
 
 import re, datetime, operator, logging
 import numpy as np
+import io
 from collections import namedtuple
 
 EVENT_CHANNEL = 'EDF Annotations'
@@ -182,8 +183,7 @@ class BaseEDFReader:
     try:
       if offset >= self.header['n_records'] or offset < 0:
         raise EDFInvalidOffset("0 =< offset < %d, got %d" % (self.header['n_records'], offset))
-      self.file.seek(self.header['n_header_bytes'])
-      self.file.seek(offset * self.bytes_per_record)
+      self.file.seek(self.header['n_header_bytes'] + offset * self.bytes_per_record)
       while amount is None or record_num < offset + amount:
         yield self.read_record()
         record_num += 1

--- a/eegtools/io/edfplus.py
+++ b/eegtools/io/edfplus.py
@@ -107,8 +107,7 @@ class BaseEDFReader:
     '''Read a record with data and return a list containing arrays with raw
     bytes.
     '''
-    result = []
-    
+    result = []    
     for nsamp in self.header['n_samples_per_record']:
       samples = self.file.read(nsamp * 2)
       if len(samples) != nsamp * 2:
@@ -184,7 +183,7 @@ class BaseEDFReader:
       if offset >= self.header['n_records'] or offset < 0:
         raise EDFInvalidOffset("0 =< offset < %d, got %d" % (self.header['n_records'], offset))
       self.file.seek(self.header['n_header_bytes'] + offset * self.bytes_per_record)
-      while amount is None or record_num < offset + amount:
+      while amount is None or record_num < amount:
         yield self.read_record()
         record_num += 1
     except EDFEndOfData:

--- a/eegtools/io/edfplus_test.py
+++ b/eegtools/io/edfplus_test.py
@@ -40,7 +40,18 @@ def test_with_generate_edf():
   # check .2 Hz block wave
   target = np.sin(.2 * np.pi * 2 * np.arange(1, block.size + 1) / fs[1]) >= 0
   assert np.max((block - target) ** 2) < 1e-4
-
+  
+  # check again with partial read - need to reopen file to reset cursor 
+  reader = edfplus.BaseEDFReader(
+    open(os.path.join(os.path.dirname(__file__), 
+    'data', 'sine3Hz_block0.2Hz.edf'), 'rb'))
+  reader.read_header()
+  recs = list(reader.select_records(offset=1, amount=1))
+  time = zip(*recs)[0]
+  signals = zip(*recs)[1]
+  assert len(signals[0][0]) == 100 * 10
+  assert len(signals[0][1]) == 12.8 * 10
+  
 
 def test_edfplus_tal():
   mult_annotations = '+180\x14Lights off\x14Close door\x14\x00'


### PR DESCRIPTION
as part of a project I'm developing, I needed to be able to efficiently parse big EDF files lying on remote network/cloud storage, without the need to read all the file. 

I quickly implemented a new method to get only a selection of records. No significant changes have been made to original code, apart some minor added feature. New method is tested alongside old ones, with some added testing conditions as well.